### PR TITLE
Fixed a common typo in comments

### DIFF
--- a/include/ma/bind_asio_handler.hpp
+++ b/include/ma/bind_asio_handler.hpp
@@ -30,7 +30,7 @@ namespace detail {
  * Functors created by listed binders forward Asio allocation/execution
  * strategies to the ones provided by source handler.
  *
- * "Alloctaion strategy" means handler related pair of free functions:
+ * "Allocation strategy" means handler related pair of free functions:
  * asio_handler_allocate and asio_handler_deallocate or the default ones
  * defined by Asio.
  * http://www.boost.org/doc/libs/1_53_0/doc/html/boost_asio/reference/Handler.html

--- a/include/ma/context_alloc_handler.hpp
+++ b/include/ma/context_alloc_handler.hpp
@@ -24,9 +24,9 @@
 
 namespace ma {
 
-/// Wrappers that override alloctaion strategy of the source handler.
+/// Wrappers that override allocation strategy of the source handler.
 /**
- * "Alloctaion strategy" means handler related pair of free functions:
+ * "Allocation strategy" means handler related pair of free functions:
  * asio_handler_allocate and asio_handler_deallocate or the default ones
  * defined by Asio.
  * http://www.boost.org/doc/libs/1_53_0/doc/html/boost_asio/reference/Handler.html
@@ -37,7 +37,7 @@ namespace ma {
  *
  * Functors created by listed wrappers:
  *
- * @li override Asio alloctaion strategy to the one provided by context
+ * @li override Asio allocation strategy to the one provided by context
  * parameter.
  * @li forward Asio execution strategy to the one provided by handler
  * parameter.

--- a/include/ma/context_wrapped_handler.hpp
+++ b/include/ma/context_wrapped_handler.hpp
@@ -27,7 +27,7 @@ namespace ma {
 /// Wrappers that override allocation/execution strategies of the source
 /// handler.
 /**
- * "Alloctaion strategy" means handler related pair of free functions:
+ * "Allocation strategy" means handler related pair of free functions:
  * asio_handler_allocate and asio_handler_deallocate or the default ones
  * defined by Asio.
  * http://www.boost.org/doc/libs/1_53_0/doc/html/boost_asio/reference/Handler.html
@@ -38,7 +38,7 @@ namespace ma {
  *
  * Functors created by listed wrappers:
  *
- * @li override Asio alloctaion strategy to the one provided by context
+ * @li override Asio allocation strategy to the one provided by context
  * parameter.
  * @li override Asio execution strategy to the one provided by handler
  * parameter.

--- a/include/ma/custom_alloc_handler.hpp
+++ b/include/ma/custom_alloc_handler.hpp
@@ -25,10 +25,10 @@
 
 namespace ma {
 
-/// Wrapper that overrides alloctaion strategy of the source handler by the
+/// Wrapper that overrides allocation strategy of the source handler by the
 /// means provided by specified handler allocator.
 /**
- * "Alloctaion strategy" means handler related pair of free functions:
+ * "Allocation strategy" means handler related pair of free functions:
  * asio_handler_allocate and asio_handler_deallocate or the default ones
  * defined by Asio.
  * http://www.boost.org/doc/libs/1_53_0/doc/html/boost_asio/reference/Handler.html
@@ -39,7 +39,7 @@ namespace ma {
  *
  * Functors created by custom_alloc_handler:
  *
- * @li override Asio alloctaion strategy by the means provided by specified
+ * @li override Asio allocation strategy by the means provided by specified
  * handler allocator.
  * @li forward Asio execution strategy to the one provided by handler
  * parameter.


### PR DESCRIPTION
This fixes instances of "alloctation" -> "allocation".

PS: Thank you for providing this repository! 😃 